### PR TITLE
Fixing issues with URLs

### DIFF
--- a/YOURLS/YOURLS.swift
+++ b/YOURLS/YOURLS.swift
@@ -37,7 +37,7 @@ public class YOURLS {
         }
     }
     public func short(url: String, with: String = "", title: String = "") -> YOURLSResponse {
-        return tools.sendHTTP(url: "\(self.getScheme())://\(domain)/\(cusConfig.getApiFilePath())", method: httpMethod.GET, urlParams: ["signature": self.signature, "action": YOURLSActions.shorturl, "url": url,"title": title, "keyword": with], bodyParams: [:])
+        return tools.sendHTTP(url: "\(self.getScheme())://\(domain)/\(cusConfig.getApiFilePath())", method: httpMethod.GET, urlParams: ["signature": self.signature, "action": YOURLSActions.shorturl, "url": url.endIndex,"title": title, "keyword": with], bodyParams: [:])
     }
     public func expand(from keyword: String) -> YOURLSResponse {
         return tools.sendHTTP(url: "\(self.getScheme())://\(domain)/\(cusConfig.getApiFilePath())", method: httpMethod.GET, urlParams: ["signature": self.signature, "action": YOURLSActions.expand, "keyword": keyword], bodyParams: [:])

--- a/YOURLS/classes.swift
+++ b/YOURLS/classes.swift
@@ -79,9 +79,11 @@ public struct Stats: Codable {
     }
 }
 // MARK: - Link
+// Making title optional to supprt old versions of YOURLS.
 public struct Link: Codable {
     let shorturl, url: String
-    let title, timestamp, ip, clicks: String
+    let timestamp, ip, clicks: String
+    var title:String?
 }
 // MARK: - Errors
 enum YOURLSErr: String, Error {

--- a/YOURLS/tools.swift
+++ b/YOURLS/tools.swift
@@ -48,3 +48,16 @@ func dictToString(_ dict: Dictionary<String, Any>) -> String{
     return  finalString
 
 }
+
+// This extension ads the ability to encode and decode URL to support URLs with Arabic and other non latin letters.
+extension String{
+    func encodeUrl() -> String
+    {
+        return self.addingPercentEncoding( withAllowedCharacters: .urlQueryAllowed) ?? ""
+    }
+    
+    func decodeUrl() -> String
+    {
+        return self.removingPercentEncoding ?? ""
+    }
+}


### PR DESCRIPTION
Fixing issues with URLs that has Arabic letters by encoding URL when prepare URLRequest, and support for old YOURLS versions by making "title" as optional due to some null values in database.